### PR TITLE
Defer removal of attack line + scalability

### DIFF
--- a/Assets/Scripts/GameboardObjects/GameboardObject.cs
+++ b/Assets/Scripts/GameboardObjects/GameboardObject.cs
@@ -162,6 +162,7 @@ public class GameboardObject : NetworkBehaviour {
         if (!isInstantiated.Value) return;
 
         if (GetModifiedHp() <= 0) {
+            StartCoroutine(SimplePause(1f)); // this should match the attack line defer time
             GameboardObjectManager.Instance.DestroyGameObject(gameObject);
         }
 
@@ -599,5 +600,10 @@ public class GameboardObject : NetworkBehaviour {
     [ServerRpc]
     public void SetIsSelectedServerRpc(bool selected) {
         isSelected.Value = selected;
+    }
+    private IEnumerator SimplePause(float seconds)
+    {
+        yield return new WaitForSecondsRealtime(seconds);
+
     }
 }

--- a/Assets/Scripts/GameboardObjects/GameboardObjectManager.cs
+++ b/Assets/Scripts/GameboardObjects/GameboardObjectManager.cs
@@ -526,7 +526,7 @@ public class GameboardObjectManager : NetworkSingleton<GameboardObjectManager>
                 if (target != null && gbo.IsValidAttack(target) && !target.IsOwner && target.GetGboType() != Types.TRAP) {
                     if (!hitSpots.ContainsKey(raycastHitSpot)) hitSpots.Add(raycastHitSpot, new HitSpot(HexColors.VALID_ATTACK, gbo.GetOccupiedRadius()));
                     Gameboard.Instance.HighlightRaycastHitSpot(hitSpots);
-
+                    LineController.Instance.DrawAttackLine(_selectedGameboardObject.gameObject, target.gameObject);
                     return;
                 }
 
@@ -653,9 +653,10 @@ public class GameboardObjectManager : NetworkSingleton<GameboardObjectManager>
             _selectedGameboardObject.GetComponent<GameboardObject>().Select();
         } else {
             if (gbo.IsValidAttack(target)) {
-                gbo.Attack(target);
                 LineController.Instance.DrawAttackLine(_selectedGameboardObject.gameObject, target.gameObject);
                 SoundManager.Instance.Play(Sounds.ATTACK);
+                LineController.Instance.DeferLineDestruction(1f);
+                gbo.Attack(target);
             } else {
                 GameManager.Instance.ShowToastMessage("Invalid attack");
                 SoundManager.Instance.Play(Sounds.INVALID);


### PR DESCRIPTION

Added 1 second to time a game object is removed due to > 0 hp and 1 second of attack line removal to compensate. 
Added code so lines from the same vector3 locations aren't drawn again (causes blinking effect) but, instead, will get more time to live.


- seems like music got turned off from previous build?
- bug: attack line for opposing player will still be redrawn after the _drawtime is up